### PR TITLE
configs: add suitesparce fix from master-next

### DIFF
--- a/configs/fixup.yml
+++ b/configs/fixup.yml
@@ -3,3 +3,9 @@
 header:
   version: 14
 
+repos:
+  meta-openembedded:
+    patches:
+      plain:
+        repo: meta-patches
+        path: meta-openembedded/0001-suitesparse-Update-after-toolchain-selection-changes.patch

--- a/meta-openembedded/0001-suitesparse-Update-after-toolchain-selection-changes.patch
+++ b/meta-openembedded/0001-suitesparse-Update-after-toolchain-selection-changes.patch
@@ -1,0 +1,105 @@
+From e2953ac39f26725da57eec35832c356c2cb0e80a Mon Sep 17 00:00:00 2001
+From: Richard Purdie <richard.purdie@linuxfoundation.org>
+Date: Fri, 20 Jun 2025 18:48:09 +0100
+Subject: [PATCH] suitesparse: Update after toolchain selection changes
+
+The toolchain selection changes mean CC is not set until after the recipe
+is parsed, breaking the manipulations made by this recipe.
+
+Replace it with code to inherit the cmake class, which correctly
+configures cmake to use the right compiler/compiler flags.
+
+We need to patch the makefiles to avoid those options being added
+incorrectly.
+
+Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ .../suitesparse/makefile-quoting.patch        | 32 +++++++++++++++++++
+ .../suitesparse/suitesparse_5.10.1.bb         | 17 +++-------
+ 2 files changed, 37 insertions(+), 12 deletions(-)
+ create mode 100644 meta-oe/recipes-devtools/suitesparse/suitesparse/makefile-quoting.patch
+
+diff --git a/meta-oe/recipes-devtools/suitesparse/suitesparse/makefile-quoting.patch b/meta-oe/recipes-devtools/suitesparse/suitesparse/makefile-quoting.patch
+new file mode 100644
+index 000000000000..6bd2ffbb5505
+--- /dev/null
++++ b/meta-oe/recipes-devtools/suitesparse/suitesparse/makefile-quoting.patch
+@@ -0,0 +1,32 @@
++OE's CC and CXX contain spaces and extra options which is incompatible with 
++cmake way of handling them. Remove passing the compiler options this way in
++favour of our normal cmake toolchain files added elsewhere.
++
++Upstream-Status: Pending
++
++Index: git/Makefile
++===================================================================
++--- git.orig/Makefile
+++++ git/Makefile
++@@ -282,7 +282,7 @@ metis: include/metis.h
++ # hardcoded below.
++ include/metis.h:
++ ifeq (,$(MY_METIS_LIB))
++-	- ( cd metis-5.1.0 && $(MAKE) config shared=1 prefix=$(SUITESPARSE) cc=$(CC) )
+++	- ( cd metis-5.1.0 && $(MAKE) config shared=1 prefix=$(SUITESPARSE) )
++ 	- ( cd metis-5.1.0 && $(MAKE) )
++ 	- ( cd metis-5.1.0 && $(MAKE) install )
++ 	- $(SO_INSTALL_NAME) $(SUITESPARSE)/lib/libmetis.dylib \
++Index: git/SuiteSparse_config/SuiteSparse_config.mk
++===================================================================
++--- git.orig/SuiteSparse_config/SuiteSparse_config.mk
+++++ git/SuiteSparse_config/SuiteSparse_config.mk
++@@ -146,7 +146,7 @@ SUITESPARSE_VERSION = 5.10.1
++         endif
++     endif
++ 
++-    CMAKE_OPTIONS += -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_C_COMPILER=$(CC)
+++    #CMAKE_OPTIONS += -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_C_COMPILER=$(CC)
++ 
++     #---------------------------------------------------------------------------
++     # CFLAGS for the C/C++ compiler
+diff --git a/meta-oe/recipes-devtools/suitesparse/suitesparse_5.10.1.bb b/meta-oe/recipes-devtools/suitesparse/suitesparse_5.10.1.bb
+index 13e6fd066c24..29f114a9dc63 100644
+--- a/meta-oe/recipes-devtools/suitesparse/suitesparse_5.10.1.bb
++++ b/meta-oe/recipes-devtools/suitesparse/suitesparse_5.10.1.bb
+@@ -4,6 +4,7 @@ SRC_URI = "git://github.com/DrTimothyAldenDavis/SuiteSparse;protocol=https;branc
+            file://0001-Preserve-CXXFLAGS-from-environment-in-Mongoose.patch \
+            file://0002-Preserve-links-when-installing-libmetis.patch \
+            file://0003-Add-version-information-to-libmetis.patch \
++           file://makefile-quoting.patch \
+            "
+ SRCREV = "538273cfd53720a10e34a3d80d3779b607e1ac26"
+ 
+@@ -14,25 +15,17 @@ DEPENDS = "cmake-native lapack gmp mpfr chrpath-native"
+ PROVIDES = "mongoose graphblas"
+ RPROVIDES:${PN} = "mongoose graphblas"
+ 
+-# The values of $CC, $CXX, and $LD that Bitbake uses have spaces in them which
+-# causes problems when the SuiteSparse Makefiles try to pass these values on
+-# the command line. To get around this problem, set these variables to only the
+-# program name and prepend the rest of the value onto the corresponding FLAGS
+-# variable.
+-CFLAGS:prepend := "${@" ".join(d.getVar('CC').split()[1:])} "
+-export CC := "${@d.getVar('CC').split()[0]}"
++inherit cmake
+ 
+-CXXFLAGS:prepend := "${@" ".join(d.getVar('CXX').split()[1:])} "
+-export CXX := "${@d.getVar('CXX').split()[0]}"
+-
+-LDFLAGS:prepend := "${@" ".join(d.getVar('LD').split()[1:])} "
+-export LD := "${@d.getVar('LD').split()[0]}"
++B = "${S}"
+ 
+ export CMAKE_OPTIONS = " \
+     -DCMAKE_INSTALL_PREFIX=${D}${prefix} \
+     -DCMAKE_INSTALL_LIBDIR=${baselib} \
+ "
+ 
++OECMAKE_SOURCEPATH = "${S}/Mongoose ${S}/metis-5.1.0 ${S}/GraphBLAS"
++
+ do_compile () {
+ 	oe_runmake library
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
Patch origin:
  https://github.com/openembedded/meta-openembedded/commit/756366778d37dd8a1cfb5286e12828474f90e94e

Fixes below error:
  Parsing recipes...ERROR: ExpansionError during parsing /srv/pokybuild/yocto-worker/meta-virt/build/meta-openembedded/meta-oe/recipes-devtools/suitesparse/suitesparse_5.10.1.bb
  bb.data_smart.ExpansionError: Failure expanding variable CFLAGS:prepend[:=], expression was ${@" ".join(d.getVar('CC').split()[1:])}  which triggered exception AttributeError: 'NoneType' object has no attribute 'split'
  The variable dependency chain for the failure is: CFLAGS:prepend[:=]

  ERROR: Parsing halted due to errors, see error messages above